### PR TITLE
Allow user to supply per directory config file

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_clang.py
+++ b/rplugin/python3/deoplete/sources/deoplete_clang.py
@@ -54,6 +54,28 @@ class Source(Base):
             clang.Config.set_library_file(self.library_path)
             clang.Config.set_compatibility_check(False)
 
+        #search for .clang file
+        path = os.path.dirname(self.vim.current.buffer.name)
+        while not os.path.isfile(path + "/.clang"):
+            if path == "/":
+                break
+            path = os.path.realpath(path + "/..")
+
+        path2 = path+"/.clang"
+        if os.path.isfile(path2):
+            flags_file = open(path2)
+            flags = flags_file.read()
+            m = re.match(r'^flags\s*=\s*', flags)
+            if m is not None:
+                self.completion_flags = flags[m.end():].split()
+            else :
+                m = re.match(r'^comilation_database\s*=\s*', flags)
+                if m is not None:
+                    path3 = flags[m.end():]
+                    if path3[0] == '"' and path3[-1] == '"':
+                        path3 = path3[1:-1]
+                    clang_complete_database = path+path3
+
         if clang_complete_database:
             self.compilation_database = \
                 clang.CompilationDatabase.fromDirectory(


### PR DESCRIPTION
Search for a `.clang` file in current or parent directory. The file will contain one line configuration, which is either:
```
flags = <flags>
```
or:
```
compilation_database = "<path to compilation_database>"
```

This allows user to have a per-directory base compile flags