### PR TITLE
Header files completion, allows for non-existent compilation database.

### DIFF
--- a/plugin/deoplete-clang.vim
+++ b/plugin/deoplete-clang.vim
@@ -24,3 +24,10 @@ let g:deoplete#sources#clang#clang_complete_database =
 
 let g:deoplete#sources#clang#debug =
       \ get(g:, 'deoplete#sources#clang#debug', 0)
+
+let g:deoplete#sources#clang#default_file =
+      \ get(g:, 'deoplete#sources#clang#default_file', '')
+
+let g:deoplete#sources#clang#test_extensions =
+      \ get(g:, 'deoplete#sources#clang#test_extensions',
+      \   {'.h': ['.c', '.cpp', '.m', '.mm'], '.hpp': ['.cpp']})

--- a/rplugin/python3/deoplete/sources/deoplete_clang.py
+++ b/rplugin/python3/deoplete/sources/deoplete_clang.py
@@ -76,7 +76,7 @@ class Source(Base):
             if m is not None:
                 self.completion_flags = flags[m.end():].split()
             else :
-                m = re.match(r'^comp?ilation_database\s*=\s*', flags)
+                m = re.match(r'^compilation_database\s*=\s*', flags)
                 if m is not None:
                     path3 = flags[m.end():]
                     if path3[0] == '"' and path3[-1] == '"':

--- a/rplugin/python3/deoplete/sources/deoplete_clang.py
+++ b/rplugin/python3/deoplete/sources/deoplete_clang.py
@@ -40,6 +40,13 @@ class Source(Base):
             self.vim.vars["deoplete#sources#clang#sort_algo"]
         self.std = \
             self.vim.vars["deoplete#sources#clang#std"]
+
+        self.default_filename = \
+            self.vim.vars["deoplete#sources#clang#default_file"]
+
+        self.test_extensions = \
+            self.vim.vars["deoplete#sources#clang#test_extensions"]
+
         self.std_c = self.std.get('c')
         self.std_cpp = self.std.get('cpp')
         self.std_objc = self.std.get('objc')
@@ -69,14 +76,14 @@ class Source(Base):
             if m is not None:
                 self.completion_flags = flags[m.end():].split()
             else :
-                m = re.match(r'^comilation_database\s*=\s*', flags)
+                m = re.match(r'^comp?ilation_database\s*=\s*', flags)
                 if m is not None:
                     path3 = flags[m.end():]
                     if path3[0] == '"' and path3[-1] == '"':
                         path3 = path3[1:-1]
                     clang_complete_database = path+path3
 
-        if clang_complete_database:
+        if clang_complete_database and os.path.isdir(clang_complete_database):
             self.compilation_database = \
                 clang.CompilationDatabase.fromDirectory(
                     clang_complete_database)
@@ -147,9 +154,10 @@ class Source(Base):
         include_dir = self.clang_header
         if not include_dir:
             return ''
-        versions = os.listdir(include_dir)
+        versions = sorted([d for d in os.listdir(include_dir)
+                           if os.path.isdir(os.path.join(include_dir, d))])
+
         # Use latest clang version
-        sorted(versions)
         latest = versions[-1]
 
         return os.path.join(include_dir, latest, 'include')
@@ -168,22 +176,57 @@ class Source(Base):
 
         header = self.get_builtin_clang_header()
         if header:
-            params.append('-I' + header)
+            param = '-I' + header
+
+            if not param in params:
+                params.append(param)
 
         self.params[fname] = params
         return params
+
+    def get_commands_for_file(self, fname):
+        assert bool(self.compilation_database)
+
+        get_cmds = self.compilation_database.getCompileCommands
+        commands = get_cmds(fname)
+
+        if commands is not None:
+            return (fname, commands)
+
+        noext_name, extension = os.path.splitext(fname)
+
+        test_for = self.test_extensions.get(extension, None)
+
+        if test_for is not None:
+            for test_ext in test_for:
+                test_fname = noext_name + test_ext
+                commands = get_cmds(test_fname)
+
+                if commands is not None:
+                    return (test_fname, commands)
+
+        if self.default_filename:
+            test_fname = self.default_filename
+
+            commands = get_cmds(test_fname)
+            if commands is not None:
+                return (test_fname, commands)
+
+        return None
 
     def get_compilation_database(self, fname):
         params = self.completion_flags
 
         if self.compilation_database:
-            cmds = self.compilation_database.getCompileCommands(fname)[0]
-            if cmds is not None:
+            used_fname, cmds = self.get_commands_for_file(fname)
+
+            if cmds is not None and cmds[0] is not None:
+                cmds = cmds[0]
                 cwd = cmds.directory
                 skip = 1
                 for arg in cmds.arguments:
                     if skip or arg in \
-                            ['-c', fname,
+                            ['-c', used_fname,
                              os.path.realpath(os.path.join(cwd, arg))]:
                         skip = 0
                         continue


### PR DESCRIPTION
Hi. Since you don't usually compile your header files directly, no compilation commands are generated for them, which results, for tools like this, that can rely on compilation databases, in either basic completion support for header files or, in worst case scenarios, in no completion support at all.

This PR introduces a heuristic to try and match a header file to its correspondent .c/.cpp/.m/.mm file and get the compile commands for the later to apply to the former. This heuristic is made configurable by adding an option, `g:deoplete#sources#clang#test_extensions`, which matches known extensions that won't generate compilation commands, like ".h" and ".hpp", to extensions that do have compilation commands and are generally named the same, like ".c" or ".cpp".

If this fails, it also introduces the option `g:deoplete#sources#clang#default_file`, which may allow the user to name e.g. "main.cpp" as the fallback file to get compilation commands for and use it in files that doesn't match anything in the compilation database. It's useful if you're using some non-standard libraries (in my case, sfml), as it makes the editor able to complete the `sf::` namespace even in header files.

This also adds a check with `os.path.isdir` for the compilation database, so it doesn't fail when the directory doesn't exist.

It also removes regular files for the clang header directory search, since in some Linux distributions (in my case, Arch) there are files like "c++-analyzer" in that directory and it was getting picked up instead of the correct clang headers.

Finally, this PR fixes what seems to be typo in the regex pattern for the compilation database in the flags files, where it was checking for "comilation_database" instead of "compilation_database". With the question mark, though, it remains backwards compatible for any one who might have picked up on it and was using it with the typo.

If there's anything you'd like me to address to get this PR accepted, just say it and I'll get it fixed. Thanks for your amazing work!