### PR TITLE
Support for absolute path for compilation database

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_clang.py
+++ b/rplugin/python3/deoplete/sources/deoplete_clang.py
@@ -104,7 +104,7 @@ class Source(Base):
                     path3 = flags[m.end():]
                     if path3[0] == '"' and path3[-1] == '"':
                         path3 = path3[1:-1]
-                    if path3[0] == '/': # absolute path
+                    if os.path.isabs(path3):
                         clang_complete_database = path3
                     else:
                         clang_complete_database = path+"/"+path3

--- a/rplugin/python3/deoplete/sources/deoplete_clang.py
+++ b/rplugin/python3/deoplete/sources/deoplete_clang.py
@@ -104,7 +104,10 @@ class Source(Base):
                     path3 = flags[m.end():]
                     if path3[0] == '"' and path3[-1] == '"':
                         path3 = path3[1:-1]
-                    clang_complete_database = path+"/"+path3
+                    if path3[0] == '/': # absolute path
+                        clang_complete_database = path3
+                    else:
+                        clang_complete_database = path+"/"+path3
 
         if clang_complete_database and os.path.isdir(clang_complete_database):
             self.compilation_database = \


### PR DESCRIPTION
When the compilation_database was loaded from the .clang it was working only for a relative path.
