### PR TITLE
Enable completion support for macros

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_clang.py
+++ b/rplugin/python3/deoplete/sources/deoplete_clang.py
@@ -319,7 +319,7 @@ class Source(Base):
 
         return tu.codeComplete(fname, line, column, buf,
                                include_macros=True,
-                               include_code_patterns=False,
+                               include_code_patterns=True,
                                include_brief_comments=False)
 
     def parse_candidates(self, result):

--- a/rplugin/python3/deoplete/sources/deoplete_clang.py
+++ b/rplugin/python3/deoplete/sources/deoplete_clang.py
@@ -318,7 +318,7 @@ class Source(Base):
             tu = self.get_translation_unit(fname, args, buf)
 
         return tu.codeComplete(fname, line, column, buf,
-                               include_macros=False,
+                               include_macros=True,
                                include_code_patterns=False,
                                include_brief_comments=False)
 


### PR DESCRIPTION
Completion support for macros had been turned off by default. I have created this pull request to re-enable it. 