### PR TITLE
fix broken compile args when clang_header is not set

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_clang.py
+++ b/rplugin/python3/deoplete/sources/deoplete_clang.py
@@ -146,7 +146,9 @@ class Source(Base):
         else:
             params = self.completion_flags + \
                 self.get_minimum_flags(context['filetype'])
-            params.append('-I' + self.get_builtin_clang_header())
+            header = self.get_builtin_clang_header()
+            if header:
+                params.append('-I' + header)
 
         complete = self.get_completion(
             buf.name, line, col,


### PR DESCRIPTION
When the clang_header is not set and the compile_database is not available, the compilation_flags are generated with a dangling `-I`, which causes the parse of translation unit to fail. This patch fix this problem.